### PR TITLE
added mode numeric

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var QRCode = require('./lib/QRCode');
 var ErrorCorrectLevel = require('./lib/ErrorCorrectLevel');
+var Mode = require('./lib/mode');
 
 var qrcode = function(data, opt) {
 	opt = opt || {};
   var level = isNaN(opt.errorCorrectLevel) ? ErrorCorrectLevel.H : opt.errorCorrectLevel;
   var qr = new QRCode(opt.typeNumber || -1, level);
-  qr.addData(data);
+  qr.addData(data, opt.mode || Mode.MODE_8BIT_BYTE);
 	qr.make();
 
 	return qr;
@@ -14,4 +15,3 @@ var qrcode = function(data, opt) {
 qrcode.ErrorCorrectLevel = ErrorCorrectLevel;
 
 module.exports = qrcode;
-

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -4,7 +4,7 @@ var BitBuffer = require('./BitBuffer');
 var util = require('./util');
 var Polynomial = require('./Polynomial');
 var Mode = require('./mode');
-var QRNumber = require('./QRNumber');
+var QrNumber = require('./QRNumber');
 
 function QRCode(typeNumber, errorCorrectLevel) {
 	this.typeNumber = typeNumber;

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -3,6 +3,8 @@ var RSBlock = require('./RSBlock');
 var BitBuffer = require('./BitBuffer');
 var util = require('./util');
 var Polynomial = require('./Polynomial');
+var Mode = require('./mode');
+var QRNumber = require('./QRNumber');
 
 function QRCode(typeNumber, errorCorrectLevel) {
 	this.typeNumber = typeNumber;
@@ -16,8 +18,21 @@ function QRCode(typeNumber, errorCorrectLevel) {
 // for client side minification
 var proto = QRCode.prototype;
 
-proto.addData = function(data) {
-	var newData = new BitByte(data);
+proto.addData = function(data, mode) {
+  mode = mode || Mode.MODE_8BIT_BYTE;
+
+  var newData = null;
+
+  switch(mode) {
+    default:
+    case Mode.MODE_8BIT_BYTE:
+      newData = new BitByte(data);
+    break;
+
+    case Mode.MODE_NUMBER:
+      newData = new QrNumber(data);
+    break;
+  }
 	this.dataList.push(newData);
 	this.dataCache = null;
 };
@@ -61,14 +76,14 @@ proto.make = function() {
 };
 
 proto.makeImpl = function(test, maskPattern) {
-	
+
 	this.moduleCount = this.typeNumber * 4 + 17;
 	this.modules = new Array(this.moduleCount);
-	
+
 	for (var row = 0; row < this.moduleCount; row++) {
-		
+
 		this.modules[row] = new Array(this.moduleCount);
-		
+
 		for (var col = 0; col < this.moduleCount; col++) {
 			this.modules[row][col] = null;//(col + row) % 3;
 		}
@@ -80,7 +95,7 @@ proto.makeImpl = function(test, maskPattern) {
 	this.setupPositionAdjustPattern();
 	this.setupTimingPattern();
 	this.setupTypeInfo(test, maskPattern);
-	
+
 	if (this.typeNumber >= 7) {
 		this.setupTypeNumber(test);
 	}
@@ -93,15 +108,15 @@ proto.makeImpl = function(test, maskPattern) {
 };
 
 proto.setupPositionProbePattern = function(row, col)  {
-	
+
 	for (var r = -1; r <= 7; r++) {
-		
+
 		if (row + r <= -1 || this.moduleCount <= row + r) continue;
-		
+
 		for (var c = -1; c <= 7; c++) {
-			
+
 			if (col + c <= -1 || this.moduleCount <= col + c) continue;
-			
+
 			if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
 					|| (0 <= c && c <= 6 && (r == 0 || r == 6) )
 					|| (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
@@ -109,8 +124,8 @@ proto.setupPositionProbePattern = function(row, col)  {
 			} else {
 				this.modules[row + r][col + c] = false;
 			}
-		}		
-	}		
+		}
+	}
 };
 
 proto.getBestMaskPattern = function() {
@@ -119,7 +134,7 @@ proto.getBestMaskPattern = function() {
 	var pattern = 0;
 
 	for (var i = 0; i < 8; i++) {
-		
+
 		this.makeImpl(true, i);
 
 		var lostPoint = util.getLostPoint(this);
@@ -141,14 +156,14 @@ proto.createMovieClip = function(target_mc, instance_name, depth) {
 	this.make();
 
 	for (var row = 0; row < this.modules.length; row++) {
-		
+
 		var y = row * cs;
-		
+
 		for (var col = 0; col < this.modules[row].length; col++) {
 
 			var x = col * cs;
 			var dark = this.modules[row][col];
-		
+
 			if (dark) {
 				qr_mc.beginFill(0, 100);
 				qr_mc.moveTo(x, y);
@@ -159,12 +174,12 @@ proto.createMovieClip = function(target_mc, instance_name, depth) {
 			}
 		}
 	}
-	
+
 	return qr_mc;
 };
 
 proto.setupTimingPattern = function() {
-	
+
 	for (var r = 8; r < this.moduleCount - 8; r++) {
 		if (this.modules[r][6] != null) {
 			continue;
@@ -183,22 +198,22 @@ proto.setupTimingPattern = function() {
 proto.setupPositionAdjustPattern = function() {
 
 	var pos = util.getPatternPosition(this.typeNumber);
-	
+
 	for (var i = 0; i < pos.length; i++) {
-	
+
 		for (var j = 0; j < pos.length; j++) {
-		
+
 			var row = pos[i];
 			var col = pos[j];
-			
+
 			if (this.modules[row][col] != null) {
 				continue;
 			}
-			
+
 			for (var r = -2; r <= 2; r++) {
-			
+
 				for (var c = -2; c <= 2; c++) {
-				
+
 					if (r == -2 || r == 2 || c == -2 || c == 2
 							|| (r == 0 && c == 0) ) {
 						this.modules[row + r][col + c] = true;
@@ -231,7 +246,7 @@ proto.setupTypeInfo = function(test, maskPattern) {
 	var data = (this.errorCorrectLevel << 3) | maskPattern;
 	var bits = util.getBCHTypeInfo(data);
 
-	// vertical		
+	// vertical
 	for (var i = 0; i < 15; i++) {
 
 		var mod = (!test && ( (bits >> i) & 1) == 1);
@@ -249,7 +264,7 @@ proto.setupTypeInfo = function(test, maskPattern) {
 	for (var i = 0; i < 15; i++) {
 
 		var mod = (!test && ( (bits >> i) & 1) == 1);
-		
+
 		if (i < 8) {
 			this.modules[8][this.moduleCount - i - 1] = mod;
 		} else if (i < 9) {
@@ -264,12 +279,12 @@ proto.setupTypeInfo = function(test, maskPattern) {
 };
 
 proto.mapData = function(data, maskPattern) {
-	
+
 	var inc = -1;
 	var row = this.moduleCount - 1;
 	var bitIndex = 7;
 	var byteIndex = 0;
-	
+
 	for (var col = this.moduleCount - 1; col > 0; col -= 2) {
 
 		if (col == 6) col--;
@@ -277,9 +292,9 @@ proto.mapData = function(data, maskPattern) {
 		while (true) {
 
 			for (var c = 0; c < 2; c++) {
-				
+
 				if (this.modules[row][col - c] == null) {
-					
+
 					var dark = false;
 
 					if (byteIndex < data.length) {
@@ -291,7 +306,7 @@ proto.mapData = function(data, maskPattern) {
 					if (mask) {
 						dark = !dark;
 					}
-					
+
 					this.modules[row][col - c] = dark;
 					bitIndex--;
 
@@ -301,7 +316,7 @@ proto.mapData = function(data, maskPattern) {
 					}
 				}
 			}
-							
+
 			row += inc;
 
 			if (row < 0 || this.moduleCount <= row) {
@@ -317,11 +332,11 @@ QRCode.PAD0 = 0xEC;
 QRCode.PAD1 = 0x11;
 
 QRCode.createData = function(typeNumber, errorCorrectLevel, dataList) {
-	
+
 	var rsBlocks = RSBlock.getRSBlocks(typeNumber, errorCorrectLevel);
-	
+
 	var buffer = new BitBuffer();
-	
+
 	for (var i = 0; i < dataList.length; i++) {
 		var data = dataList[i];
 		buffer.put(data.mode, 4);
@@ -355,12 +370,12 @@ QRCode.createData = function(typeNumber, errorCorrectLevel, dataList) {
 
 	// padding
 	while (true) {
-		
+
 		if (buffer.getLengthInBits() >= totalDataCount * 8) {
 			break;
 		}
 		buffer.put(QRCode.PAD0, 8);
-		
+
 		if (buffer.getLengthInBits() >= totalDataCount * 8) {
 			break;
 		}
@@ -373,13 +388,13 @@ QRCode.createData = function(typeNumber, errorCorrectLevel, dataList) {
 QRCode.createBytes = function(buffer, rsBlocks) {
 
 	var offset = 0;
-	
+
 	var maxDcCount = 0;
 	var maxEcCount = 0;
-	
+
 	var dcdata = new Array(rsBlocks.length);
 	var ecdata = new Array(rsBlocks.length);
-	
+
 	for (var r = 0; r < rsBlocks.length; r++) {
 
 		var dcCount = rsBlocks[r].dataCount;
@@ -387,14 +402,14 @@ QRCode.createBytes = function(buffer, rsBlocks) {
 
 		maxDcCount = Math.max(maxDcCount, dcCount);
 		maxEcCount = Math.max(maxEcCount, ecCount);
-		
+
 		dcdata[r] = new Array(dcCount);
-		
+
 		for (var i = 0; i < dcdata[r].length; i++) {
 			dcdata[r][i] = 0xff & buffer.buffer[i + offset];
 		}
 		offset += dcCount;
-		
+
 		var rsPoly = util.getErrorCorrectPolynomial(ecCount);
 		var rawPoly = new Polynomial(dcdata[r], rsPoly.getLength() - 1);
 
@@ -406,7 +421,7 @@ QRCode.createBytes = function(buffer, rsBlocks) {
 		}
 
 	}
-	
+
 	var totalCodeCount = 0;
 	for (var i = 0; i < rsBlocks.length; i++) {
 		totalCodeCount += rsBlocks[i].totalCount;
@@ -435,4 +450,3 @@ QRCode.createBytes = function(buffer, rsBlocks) {
 };
 
 module.exports = QRCode;
-

--- a/lib/QrNumber.js
+++ b/lib/QrNumber.js
@@ -1,0 +1,47 @@
+var mode = require('./mode');
+
+function QrNumber(data) {
+  this.mode = mode.MODE_NUMBER;
+  this.data = data;
+}
+
+QrNumber.prototype = {
+  getLength(buffer) {
+    return this.data.length;
+  },
+
+  write(buffer) {
+    var data = this.data;
+
+    let i = 0;
+
+    while (i + 2 < data.length) {
+      buffer.put(this.strToNum(data.substring(i, i + 3)), 10);
+      i += 3;
+    }
+
+    if (i < data.length) {
+      if (data.length - i === 1) {
+        buffer.put(this.strToNum(data.substring(i, i + 1)), 4);
+      } else if (data.length - i === 2) {
+        buffer.put(this.strToNum(data.substring(i, i + 2)), 7);
+      }
+    }
+  },
+
+  strToNum(s) {
+    let num = 0;
+    for (let i = 0; i < s.length; i += 1) {
+      num = num * 10 + this.chatToNum(s.charAt(i));
+    }
+    return num;
+  },
+
+  chatToNum(c) {
+    if (c >= '0' && c <= '9') {
+      return c.charCodeAt(0) - '0'.charCodeAt(0);
+    }
+  }
+};
+
+module.exports = QrNumber;


### PR DESCRIPTION
We had some numeric strings to be represented and found that the generated QR did not match our partners' QR, QR's where generated too large, after digging around this is the solution.

Wondering why this wasn't implemented in the first place, since it was already present in https://kazuhikoarase.github.io/, maybe not in time of conception of this fork?

I have not tested on this library exactly. Only tested on a copy embedded in our code.

